### PR TITLE
Removed duplicate function declaration for C23 compatibility

### DIFF
--- a/source/integrer.c
+++ b/source/integrer.c
@@ -149,8 +149,6 @@ void bezout_xx(
   piplib_int_clear(r);
 }
 
-Tableau_xx *expanser_xx();
-
 /* cut: constant parameters denominator */
 #define add_parm_xx PIPLIB_NAME(add_parm)
 static void add_parm_xx(Tableau_xx** pcontext,


### PR DESCRIPTION
Building piplib with gcc 15 fails.

`source/funcall.h:72:33: error: conflicting types for 'expanser_sp'; have 'Tableau_sp *(void)' {aka 'struct T_sp *(void)'}`
(view full error log below)

[error.log](https://github.com/user-attachments/files/26058420/error.log)

The function `expanser_xx()` is declared twice with different arguments:
in `integrer.c:152` and in `funcall.h:100`

This patch just removes the redundant declaration in `integrer.c`

The real question is why it was compiling before, and why did gcc change its behavior...
